### PR TITLE
FDA-2079 - Deleted filter for onmeda

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -33,7 +33,5 @@ faz.net#@#.js-sharebuttons
 ! FDA-2068
 boerse-online.de#@#.social_icons
 boerse-online.de#@#.social_wrapper
-! FDA-2079
-@@||spark.cloud.funkedigital.de/spark.js^$script,domain=onmeda.de
 ! FDA-2084
 gofeminin.de#@#a[href^="https://pubads.g.doubleclick.net/"]


### PR DESCRIPTION
FDA-2079 - deleted allowing filter for onmeda.de as filter that was causing issue was [removed](https://github.com/easylist/easylistgermany/commit/d68f2d6) from EasyList Germany