### PR TITLE
D: FDA-2366 and FDA-2367

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -36,5 +36,3 @@ boerse-online.de#@#.social_wrapper
 ! FDA-2302
 @@||aswpsdkus.com/notify/*/ua-html-prompt.min.js$domain=ran.de
 @@||aswpsdkus.com/notify/*/ua-sdk.min.js$domain=ran.de
-! FDA-2366 and FDA-2367
-@@||googletagmanager.com/gtm.js$script,domain=finanzen.ch|finanzen.net|finanzen.at


### PR DESCRIPTION
Remove: `@@||googletagmanager.com/gtm.js$script,domain=finanzen.ch|finanzen.net|finanzen.at`
since domains: **finanzen.net**  and **finanzen.at** were added to EasyPrivacy [filter](https://github.com/easylist/easylist/commit/7b9467a)  

finanzen.ch were already added on another [commit](https://github.com/easylist/easylist/commit/1b4e8ed): `@@||googletagmanager.com/gtm.js$script,domain=beterbed.nl|finanzen.ch|mediamarkt.nl`

