### PR TITLE
Filter for travelbook.de

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -46,5 +46,5 @@ politico.com#@##onetrust-consent-sdk
 politico.com#@##onetrust-banner-sdk
 politico.com#@#.grecaptcha-badge
 politico.com#@#.social-tools
-! FDA-2572
-@@||trc.taboola.com/travelbook/trc/*/json?tim=$domain=travelbook.de
+! FDA-2572 | FDA-2573 | FDA-2574 | FDA-2575 | FDA-2576
+@@||trc.taboola.com/*/trc/*/json?tim=$domain=travelbook.de|stylebook.de|rollingstone.de|metal-hammer.de|jetzt.de


### PR DESCRIPTION
**Commit msg:**
Adjusting filter to allow content on 6 websites blocked by Easy Privacy rule: `||taboola.com^*/json?tim= `

**Suggestion:**
`@@||trc.taboola.com/*/trc/*/json?tim=$domain=travelbook.de|stylebook.de|rollingstone.de|metal-hammer.de|jetzt.de`

**Related Tickets:** 
FDA-2572 | FDA-2573 | FDA-2574 | FDA-2575 | FDA-2576

**URLs:**
https://www.travelbook.de/orte/lost-places/villa-epecuen

https://www.stylebook.de/fashion/kaia-gerber-cindy-crawford-auftritt

https://www.rollingstone.de/george-clooney-kritisiert-rust-dreharbeiten-2379651/

https://www.metal-hammer.de/tim-lambesis-as-i-lay-dying-neue-songs-mit-neuer-band-veroeffentlicht-1879815/

https://www.jetzt.de/digital/chris-james-not-angry-tiktok-douyin-challenge-china


