### PR TITLE
A: FDA-2613

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -49,3 +49,7 @@ politico.com#@#.social-tools
 ! FDA-2572 | FDA-2573 | FDA-2574 | FDA-2575 | FDA-2576 | FDA-2577 | FDA-2579 | FDA-2584 | FDA-2585 | FDA-2588 | FDA-2590
 @@||trc.taboola.com/*/trc/*/json?tim=$domain=travelbook.de|stylebook.de|rollingstone.de|metal-hammer.de|jetzt.de|sport1.de|fitbook.de|musikexpress.de|sportbild.bild.de|techbook.de|myhomebook.de
 @@||taboola.com/libtrc/$script,domain=sport1.de|myhomebook.de
+! FDA-2613
+@@||scdn.cxense.com/cx.cce.js$domain=handelsblatt.com
+@@||cdn.cxense.com/cx.js$domain=handelsblatt.com
+@@||api.cxense.com/public/widget/data?$domain=handelsblatt.com


### PR DESCRIPTION
Allows quiz on https://www.handelsblatt.com/ blocked by Easy Privacy rule: `||cxense.com^$third-party`
Those exception rues are already in Easy Privacy so I'm going to email FLA to see if he can add **handelsblatt.com** to those rules.

<img width="1234" alt="hnd" src="https://user-images.githubusercontent.com/57706597/144626237-a7e773c2-8606-4c80-9b15-7d32209ba0ff.png">

