### PR TITLE
A: FDA-2612

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -53,3 +53,6 @@ politico.com#@#.social-tools
 @@||scdn.cxense.com/cx.cce.js$domain=handelsblatt.com
 @@||cdn.cxense.com/cx.js$domain=handelsblatt.com
 @@||api.cxense.com/public/widget/data?$domain=handelsblatt.com
+! FDA-2612
+@@||adnxs-simple.com/mob?$xmlhttprequest,domain=sportbild.bild.de
+@@||asadcdn.com/adlib/*$script,domain=sportbild.bild.de


### PR DESCRIPTION
Allow BildBet buttons on: https://sportbild.bild.de/bundesliga/startseite/1-bundesliga/home-33207854.sport.html

Different Easy List and Easy Privacy rules block those buttons. 


**1 - EasyList**
Filter causing the issue: `||adnxs-simple.com^`
Suggestion: `@@||adnxs-simple.com/mob?$xmlhttprequest,domain=sportbild.bild.de`


**2 - EasyPrivacy**
Filter causing the issue: `||asadcdn.com^$third-party`
Suggestion: `@@||asadcdn.com/adlib/*$script,domain=sportbild.bild.de`


<img width="575" alt="sb" src="https://user-images.githubusercontent.com/57706597/144634827-18c76fac-7127-45f0-b6f0-7f7ad85454bc.png">

