### PR TITLE
D: FDA-2665

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -49,5 +49,3 @@ politico.com#@#.social-tools
 ! FDA-2572 | FDA-2573 | FDA-2574 | FDA-2575 | FDA-2576 | FDA-2577 | FDA-2579 | FDA-2584 | FDA-2585 | FDA-2588 | FDA-2590
 @@||trc.taboola.com/*/trc/*/json?tim=$domain=travelbook.de|stylebook.de|rollingstone.de|metal-hammer.de|jetzt.de|sport1.de|fitbook.de|musikexpress.de|sportbild.bild.de|techbook.de|myhomebook.de
 @@||taboola.com/libtrc/$script,domain=sport1.de|myhomebook.de
-! FDA-2665
-@@||getjad.io/library/$script,domain=gamestar.de


### PR DESCRIPTION
Deleted allowing rule for gamestar.de (to be merged later this week).
Rules were moved accordingly to ELGermany: 
https://github.com/easylist/easylist/commit/7ab2016
https://github.com/easylist/easylistgermany/commit/b5d79a9



