### PR TITLE
D: FDA-2672 and FDA-2675

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -54,7 +54,6 @@ politico.com#@#.social-tools
 ! FDA-2670
 @@||scdn.cxense.com/cx.js$domain=welt.de
 ! FDA-2672 | FDA-2675
-@@||googletagmanager.com/gtm.js?$domain=idealo.de|idealo.at
 @@||hotjar.com^$domain=idealo.de
 @@||siteintercept.qualtrics.com/*$domain=idealo.at
 ! FDA-2674


### PR DESCRIPTION
Removed rule: `@@||googletagmanager.com/gtm.js?$domain=idealo.de|idealo.at` as exception rule was added to EasyPrivacy: [58ecab1](https://github.com/easylist/easylist/commit/58ecab1)


Left: `@@||hotjar.com^$domain=idealo.de` (FDA-2672) AND `@@||siteintercept.qualtrics.com/*$domain=idealo.at` (FDA-2675) as these rules were not added to EasyPrivacy (no replies from the FLA).