### PR TITLE
D: FDA-2674

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -56,5 +56,3 @@ politico.com#@#.social-tools
 ! FDA-2672 | FDA-2675
 @@||hotjar.com^$domain=idealo.de
 @@||siteintercept.qualtrics.com/*$domain=idealo.at
-! FDA-2674
-wetter.com#@#div[id^="div-gpt-"]


### PR DESCRIPTION
Removed rule: `wetter.com#@#div[id^="div-gpt-"]` as exception was added to EasyList Germany: [af88f8a](https://github.com/easylist/easylistgermany/commit/af88f8a)


