### PR TITLE
A: FDA-2683

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -56,3 +56,6 @@ politico.com#@#.social-tools
 ! FDA-2672 | FDA-2675
 @@||hotjar.com^$domain=idealo.de
 @@||siteintercept.qualtrics.com/*$domain=idealo.at
+! FDA-2683
+@@||bilder-a.akamaihd.net/ip/js/ipdvdc/ipdvdc.min.js^$domain=n-tv.de
+@@||technical-service.net^$image,xmlhttprequest,domain=n-tv.de


### PR DESCRIPTION
Allow video on https://www.n-tv.de/panorama/Omikron-Welle-fordert-Corona-Warn-App-heraus-article23068448.html
blocked by EasyPrivacy rules: 
```
/ipdvdc/*
||technical-service.net^$third-party
```

<img width="1121" alt="nk" src="https://user-images.githubusercontent.com/57706597/150141100-73a69658-6fef-43fd-8258-b705ad557ace.png">
<img width="900" alt="nm" src="https://user-images.githubusercontent.com/57706597/150141114-a9b0af54-e245-413c-a14b-9c491e7144ae.png">

