### PR TITLE
A: FDA-2753

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -56,3 +56,5 @@ politico.com#@#.social-tools
 ! FDA-2672 | FDA-2675
 @@||hotjar.com^$domain=idealo.de
 @@||siteintercept.qualtrics.com/*$domain=idealo.at
+! FDA-2753
+gamestar.de#@#.content-item-small:-abp-has(h3:-abp-contains(Anzeige))


### PR DESCRIPTION
Allow missing content on http://www.gamestar.de/

Content placed on AKTUELL sidebar at the left side and are labeled as [Anzeige].
Although they are labeled as [Anzeige] they link to the website itself.

ELGermany rule causing the issue: `[gamestar.de#?#.content-item-small:-abp-has(h3:-abp-contains(Anzeige))](http://gamestar.de/#?%23.content-item-small:-abp-has(h3:-abp-contains(Anzeige)))`

![mc](https://user-images.githubusercontent.com/57706597/153167304-3c3f40d6-da5a-495a-a2fc-5e614faeb314.jpeg)

