### PR TITLE
A: FDA-2760

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -62,3 +62,5 @@ politico.com#@#.social-tools
 11freunde.de#@#.js_deferred-ad
 @@||native.emsservice.de/teasers/*.json$domain=11freunde.de
 @@||native.emsservice.de/images/teaser*_*.jpeg$domain=11freunde.de
+! FDA-2760
+@@||cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/*.png$domain=wetter.com


### PR DESCRIPTION
Allow image logo on https://www.wetter.com/reise/tirol-winter/

EL rule causing the issue: `/images/ads/*$domain=~oppdrettstorget.no`
Blocking the following images:
https://cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/achensee_logo.png
https://cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/ischgl_logo.png
https://cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/tiroler_zugspitz_logo.png


![wetter](https://user-images.githubusercontent.com/57706597/153377734-26c130d5-3696-4399-a234-e51f0c1122f5.jpeg)

