### PR TITLE
D: FDA-2760

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -58,4 +58,3 @@ politico.com#@#.social-tools
 @@||siteintercept.qualtrics.com/*$domain=idealo.at
 ! FDA-2760
 @@||cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/*.png$domain=wetter.com
-@@||cs3.wettercomassets.com/wcomv5/images/footer/google-play.png$domain=wetter.com


### PR DESCRIPTION
Deleted rule that allows the Google Play image on https://www.wetter.com/reise/tirol-winter/ as exception was added to Fanboy's Social Blocking List: https://github.com/easylist/easylist/commit/02f8ae5

Hence keeping `@@||[cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/*.png$domain=wetter.com` EL FLA said those are ads and should remain blocked.

