### PR TITLE
D: FDA-2963

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -57,8 +57,5 @@ politico.com#@#.social-tools
 @@||siteintercept.qualtrics.com/*$domain=idealo.at
 ! FDA-2760
 @@||cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/*.png$domain=wetter.com
-! FDA-2963
-@@||stroeerdigitalgroup.de/metatag/live/AMS/metaTag.min.js$domain=auto-motor-und-sport.de
-@@||mps-gba.de/praeludium/ams.js?$domain=auto-motor-und-sport.de
 ! FDA-2966
 @@||googletagmanager.com/gtm.js?$domain=wetter.de


### PR DESCRIPTION
Reference: https://github.com/abp-filters/abp-filters-compliance/pull/41

Deleted exceptions as issue is now fixed in EasyPrivacy: https://github.com/easylist/easylist/commit/b14ee9e

- Khrin removed from EasyPrivacy one of filter blocking the video: `/metaTag.min.js`

- He also added one more exception for rule: `||mps-gba.de^$third-party` >> `@@||online.mps-gba.de/praeludium_src/fix_addons/noJump.js$domain=auto-motor-und-sport.de
`
