### PR TITLE
A: FDA-2998

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -59,3 +59,5 @@ politico.com#@#.social-tools
 @@||cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/*.png$domain=wetter.com
 ! FDA-2966
 @@||googletagmanager.com/gtm.js?$domain=wetter.de
+! FDA-2998
+freetech.academy#@##sb_instagram


### PR DESCRIPTION
Allow instagram widget hidden by rule: `###sb_instagram` from Fanboy's Social Blocking List.

<img width="1294" alt="scx" src="https://user-images.githubusercontent.com/57706597/171589295-5b463035-15f6-42ed-9498-f878ab0b69d1.png">

<img width="1340" alt="scw" src="https://user-images.githubusercontent.com/57706597/171589232-1f605684-2fe3-45d6-a707-9f9c6c842929.png">
