### PR TITLE
A: FD-3083

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -59,14 +59,3 @@ politico.com#@#.social-tools
 @@||cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/*.png$domain=wetter.com
 ! FDA-2966
 @@||googletagmanager.com/gtm.js?$domain=wetter.de
-! FD-3083
-@@||asadcdn.com/adlib/pages/autobild.js$domain=autobild.de
-@@||asadcdn.com/adlib/libmodules/$script,domain=autobild.de
-||auto-bild.de/js/rd/google.js$domain=autobild.de
-||googletagservices.com/dcm/dcmads.js$domain=autobild.de
-||ad.doubleclick.net^$domain=autobild.de
-||2mdn.net^$domain=autobild.de
-||tpc.googlesyndication.com^$domain=autobild.de
-||track.webgains.com/link.html?wglinkid=$script,domain=autobild.de
-||a.df-srv.de^$domain=autobild.de
-||adnxs-simple.com/creative/$domain=autobild.de


### PR DESCRIPTION
**Delete rules for autobild.de**


**Fixes:**
1 - FLA adjusted rule causing the issue to `||asadcdn.com/adlib/$~script,domain=autobild.de`
https://github.com/easylist/easylistgermany/commit/d8288db instead of adding exceptions:
`@@||asadcdn.com/adlib/pages/autobild.js$domain=autobild.de`
`@@||asadcdn.com/adlib/libmodules/$script,domain=autobild.de`


2 - FLA added suggested blocking rules:
https://github.com/easylist/easylistgermany/commit/e27c59e
https://github.com/easylist/easylistgermany/commit/fd6cd37 - adjustment for `||2mdn.net^$domain=autobild.de` 

`||auto-bild.de/js/rd/google.js$domain=autobild.de`
`||googletagservices.com/dcm/dcmads.js$domain=autobild.de`
`||ad.doubleclick.net^$domain=autobild.de`
`||2mdn.net^$domain=autobild.de` **adjusted to** `||2mdn.net^$domain=autobild.de|imasdk.googleapis.com|serving-sys.com`
`||tpc.googlesyndication.com^$domain=autobild.de`
`||track.webgains.com/link.html?wglinkid=$script,domain=autobild.de`
`||a.df-srv.de^$domain=autobild.de`
`||adnxs-simple.com/creative/$domain=autobild.de`