### PR TITLE
A: FD-3133

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -60,5 +60,4 @@ politico.com#@#.social-tools
 ! FDA-2966
 @@||googletagmanager.com/gtm.js?$domain=wetter.de
 ! FD-3133
-@@||asadcdn.com/adlib/$xmlhttprequest,domain=autobild.de
-@@||asadcdn.com/adlib/beta/branches/abtest/libmodules/extensions/$stylesheet,domain=autobild.de
+@@||asadcdn.com/adlib/$stylesheet,domain=autobild.de

--- a/germany.txt
+++ b/germany.txt
@@ -59,3 +59,6 @@ politico.com#@#.social-tools
 @@||cs3.wettercomassets.com/wcomv5/images/ADS/tirol_logos/*.png$domain=wetter.com
 ! FDA-2966
 @@||googletagmanager.com/gtm.js?$domain=wetter.de
+! FD-3133
+@@||asadcdn.com/adlib/$xmlhttprequest,domain=autobild.de
+@@||asadcdn.com/adlib/beta/branches/abtest/libmodules/extensions/$stylesheet,domain=autobild.de


### PR DESCRIPTION
Fix broken content at the bottom of the page 
https://www.autobild.de/artikel/12-handyhalterungen-fuers-fahrrad-im-test-21689453.html

EasyList Germany rule that seems to be causing the issue: `||asadcdn.com/adlib/$~script,domain=autobild.de`