### PR TITLE
A: FD-3411

### DIFF
--- a/germany.txt
+++ b/germany.txt
@@ -70,3 +70,5 @@ politico.com#@#.social-tools
 @@||api.cxense.com/public/widget/data?json=$domain=businessinsider.de
 ! FD-3367
 @@||cleverpush.com/sdk/$domain=mycleverpush.com
+! FD-3411
+@@||pushwoosh.com^$third-party,domain=wetter.com


### PR DESCRIPTION
Notification missing  on https://www.wetter.com/ when ABP is active caused by EasyPrivacy blocking `pushwoosh.com^$third-party`